### PR TITLE
Fix js dependency

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,4 +1,3 @@
-coffee/*
 coverage/*
 .gitignore
 Gruntfile.js

--- a/index.coffee
+++ b/index.coffee
@@ -1,0 +1,3 @@
+oauth_creator = require('./coffee/main')
+
+module.exports = oauth_creator()

--- a/index.js
+++ b/index.js
@@ -1,3 +1,0 @@
-var oauth_creator = require('./js/main');
-
-module.exports = oauth_creator();

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "oauthio",
   "version": "0.3.5",
   "description": "OAuth that just works ! This is the Node.js SDK for OAuth.io.",
-  "main": "index.js",
+  "main": "index.coffee",
   "scripts": {
     "test": "istanbul cover jasmine-node tests/unit/spec"
   },


### PR DESCRIPTION
- No longer need to compile back to JS
- This will allow us to use
`"oauthio": "git://github.com/saltt/sdk-node.git",` in KBX